### PR TITLE
Hide error msg when msisdn not complete - fixes #44

### DIFF
--- a/app/src/main/kotlin/pl/gov/mc/protego/backend/api/RegistrationService.kt
+++ b/app/src/main/kotlin/pl/gov/mc/protego/backend/api/RegistrationService.kt
@@ -15,7 +15,7 @@ class RegistrationService (
     ) {
 
     fun initRegistration(msisdn: String): Single<RegistrationResponse> =
-        Single.just(msisdn.withCountyCode(MsisdnCountryCode.PL))
+        Single.just(msisdn.withCountryCode(MsisdnCountryCode.PL))
         .doOnSuccess { if(!msisdnValidator.validateWithCountryCode(it)) {
             throw InvalidMsisdnException("$it is not a valid MSISDN")
         } }
@@ -28,5 +28,5 @@ class RegistrationService (
             .flatMap { registrationAPI.confirmRegistration(it) }
 }
 
-private fun String.withCountyCode(countryCode: MsisdnCountryCode): String
+private fun String.withCountryCode(countryCode: MsisdnCountryCode): String
     = "${countryCode.code}$this"

--- a/app/src/main/kotlin/pl/gov/mc/protego/ui/registration/RegistrationActivity.kt
+++ b/app/src/main/kotlin/pl/gov/mc/protego/ui/registration/RegistrationActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
 import android.widget.Toast
+import androidx.core.view.isVisible
 import com.google.android.material.textfield.TextInputEditText
 import com.polidea.cockpit.cockpit.Cockpit
 import kotlinx.android.synthetic.main.registration_view.*
@@ -15,6 +16,9 @@ import pl.gov.mc.protego.ui.base.BaseActivity
 import pl.gov.mc.protego.ui.main.DashboardActivity
 import pl.gov.mc.protego.ui.observeLiveData
 import pl.gov.mc.protego.ui.scrollWhenFocusObtained
+import pl.gov.mc.protego.ui.validator.MsisdnIncomplete
+import pl.gov.mc.protego.ui.validator.MsisdnInvalid
+import pl.gov.mc.protego.ui.validator.MsisdnOk
 
 
 class RegistrationActivity : BaseActivity() {
@@ -25,6 +29,7 @@ class RegistrationActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.registration_view)
 
+        register_button.isVisible = false
         register_button.setOnClickListener {
             registrationViewModel.onStartRegistration(msisdn_edit_text.text.toString())
         }
@@ -71,7 +76,9 @@ class RegistrationActivity : BaseActivity() {
 
     private fun observeMsisdnValidation() {
         observeLiveData(registrationViewModel.msisdnError) {
-            msisdn_edit_text_layout.error = it
+            register_button.isVisible = it == MsisdnOk
+            msisdn_edit_text_layout.error =
+                if (it == MsisdnInvalid) "Niepoprawny numer telefonu" else null
         }
     }
 

--- a/app/src/main/kotlin/pl/gov/mc/protego/ui/registration/RegistrationActivity.kt
+++ b/app/src/main/kotlin/pl/gov/mc/protego/ui/registration/RegistrationActivity.kt
@@ -29,7 +29,7 @@ class RegistrationActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.registration_view)
 
-        register_button.isVisible = false
+        register_button.isEnabled = false
         register_button.setOnClickListener {
             registrationViewModel.onStartRegistration(msisdn_edit_text.text.toString())
         }
@@ -76,7 +76,7 @@ class RegistrationActivity : BaseActivity() {
 
     private fun observeMsisdnValidation() {
         observeLiveData(registrationViewModel.msisdnError) {
-            register_button.isVisible = it == MsisdnOk
+            register_button.isEnabled = it == MsisdnOk
             msisdn_edit_text_layout.error =
                 if (it == MsisdnInvalid) "Niepoprawny numer telefonu" else null
         }

--- a/app/src/main/kotlin/pl/gov/mc/protego/ui/registration/RegistrationActivity.kt
+++ b/app/src/main/kotlin/pl/gov/mc/protego/ui/registration/RegistrationActivity.kt
@@ -31,7 +31,7 @@ class RegistrationActivity : BaseActivity() {
 
         register_button.isEnabled = false
         register_button.setOnClickListener {
-            registrationViewModel.onStartRegistration(msisdn_edit_text.text.toString())
+            registrationViewModel.onStartRegistration(msisdn_edit_text.text.toString().replace(" ", ""))
         }
 
         msisdn_edit_text.onTextChanged(registrationViewModel::onNewMsisdn)

--- a/app/src/main/kotlin/pl/gov/mc/protego/ui/registration/RegistrationViewModel.kt
+++ b/app/src/main/kotlin/pl/gov/mc/protego/ui/registration/RegistrationViewModel.kt
@@ -33,7 +33,7 @@ class RegistrationViewModel(
     }
 
     fun onNewMsisdn(msisdn: String) {
-        msisdnError.value = msisdnValidator.validate(msisdn)
+        msisdnError.value = msisdnValidator.validate(msisdn.replace(" ", ""))
     }
 
     fun onStartRegistration(msisdn: String) {

--- a/app/src/main/kotlin/pl/gov/mc/protego/ui/registration/RegistrationViewModel.kt
+++ b/app/src/main/kotlin/pl/gov/mc/protego/ui/registration/RegistrationViewModel.kt
@@ -10,6 +10,9 @@ import io.reactivex.schedulers.Schedulers
 import pl.gov.mc.protego.backend.domain.ProtegoServer
 import pl.gov.mc.protego.information.Session
 import pl.gov.mc.protego.information.SessionData
+import pl.gov.mc.protego.ui.validator.MsisdnInvalid
+import pl.gov.mc.protego.ui.validator.MsisdnOk
+import pl.gov.mc.protego.ui.validator.MsisdnValidationResult
 import pl.gov.mc.protego.ui.validator.MsisdnValidator
 import timber.log.Timber
 
@@ -19,7 +22,7 @@ class RegistrationViewModel(
     private val session: Session
 )  : ViewModel() {
 
-    val msisdnError = MutableLiveData<String?>()
+    val msisdnError = MutableLiveData<MsisdnValidationResult>()
     val sessionData = MutableLiveData<SessionData>()
 
     private var disposables = CompositeDisposable()
@@ -30,11 +33,7 @@ class RegistrationViewModel(
     }
 
     fun onNewMsisdn(msisdn: String) {
-        if (!msisdnValidator.validate(msisdn)) {
-            msisdnError.value = "Niepoprawny numer telefonu"
-        } else {
-            msisdnError.value = null
-        }
+        msisdnError.value = msisdnValidator.validate(msisdn)
     }
 
     fun onStartRegistration(msisdn: String) {

--- a/app/src/main/kotlin/pl/gov/mc/protego/ui/validator/MsisdnValidator.kt
+++ b/app/src/main/kotlin/pl/gov/mc/protego/ui/validator/MsisdnValidator.kt
@@ -17,9 +17,9 @@ class MsisdnValidator {
         when {
             msisdn.length < 2 -> MsisdnIncomplete
             msisdn.length < 9 ->
-                if (prefixes.any{msisdn.startsWith(it)}) MsisdnIncomplete else MsisdnInvalid
+                if (prefixes.any { msisdn.startsWith(it) }) MsisdnIncomplete else MsisdnInvalid
             msisdn.length == 9 ->
-                if (prefixes.any{msisdn.startsWith(it)}) MsisdnOk else MsisdnInvalid
+                if (prefixes.any { msisdn.startsWith(it) }) MsisdnOk else MsisdnInvalid
             else -> MsisdnInvalid
         }
     fun validateWithCountryCode(msisdn: String) = msisdn.length == 12

--- a/app/src/main/kotlin/pl/gov/mc/protego/ui/validator/MsisdnValidator.kt
+++ b/app/src/main/kotlin/pl/gov/mc/protego/ui/validator/MsisdnValidator.kt
@@ -15,9 +15,11 @@ class MsisdnValidator {
 
     fun validate(msisdn: String) =
         when {
+            msisdn.length < 2 -> MsisdnIncomplete
+            msisdn.length < 9 ->
+                if (prefixes.any{msisdn.startsWith(it)}) MsisdnIncomplete else MsisdnInvalid
             msisdn.length == 9 ->
                 if (prefixes.any{msisdn.startsWith(it)}) MsisdnOk else MsisdnInvalid
-            msisdn.length < 9 -> MsisdnIncomplete
             else -> MsisdnInvalid
         }
     fun validateWithCountryCode(msisdn: String) = msisdn.length == 12

--- a/app/src/main/kotlin/pl/gov/mc/protego/ui/validator/MsisdnValidator.kt
+++ b/app/src/main/kotlin/pl/gov/mc/protego/ui/validator/MsisdnValidator.kt
@@ -11,7 +11,7 @@ object MsisdnOk : MsisdnValidationResult()
 
 class MsisdnValidator {
     // https://pl.wikipedia.org/wiki/Numery_telefoniczne_w_Polsce#Sieci_ruchome_(komórkowe)
-    var prefixes = listOf(50, 51, 53, 57, 60, 66, 69, 72, 73, 78, 79, 88).map{it.toString()}
+    var prefixes = listOf(45, 50, 51, 53, 57, 60, 66, 69, 72, 73, 78, 79, 88).map{it.toString()}
 
     fun validate(msisdn: String) =
         when {

--- a/app/src/main/kotlin/pl/gov/mc/protego/ui/validator/MsisdnValidator.kt
+++ b/app/src/main/kotlin/pl/gov/mc/protego/ui/validator/MsisdnValidator.kt
@@ -2,10 +2,23 @@ package pl.gov.mc.protego.ui.validator
 
 import java.lang.IllegalArgumentException
 
-
 class InvalidMsisdnException(message: String) : IllegalArgumentException(message)
 
+sealed class MsisdnValidationResult
+object MsisdnIncomplete : MsisdnValidationResult()
+object MsisdnInvalid : MsisdnValidationResult()
+object MsisdnOk : MsisdnValidationResult()
+
 class MsisdnValidator {
-    fun validate(msisdn: String) = msisdn.length == 9
+    // https://pl.wikipedia.org/wiki/Numery_telefoniczne_w_Polsce#Sieci_ruchome_(komórkowe)
+    var prefixes = listOf(50, 51, 53, 57, 60, 66, 69, 72, 73, 78, 79, 88).map{it.toString()}
+
+    fun validate(msisdn: String) =
+        when {
+            msisdn.length == 9 ->
+                if (prefixes.any{msisdn.startsWith(it)}) MsisdnOk else MsisdnInvalid
+            msisdn.length < 9 -> MsisdnIncomplete
+            else -> MsisdnInvalid
+        }
     fun validateWithCountryCode(msisdn: String) = msisdn.length == 12
 }

--- a/app/src/main/kotlin/pl/gov/mc/protego/ui/validator/MsisdnValidator.kt
+++ b/app/src/main/kotlin/pl/gov/mc/protego/ui/validator/MsisdnValidator.kt
@@ -14,7 +14,7 @@ class MsisdnValidator {
     fun validate(msisdn: String) =
         when {
             msisdn.length < 9 -> MsisdnIncomplete
-            msisdn.length == 9 ->MsisdnOk
+            msisdn.length == 9 -> MsisdnOk
             else -> MsisdnInvalid
         }
     fun validateWithCountryCode(msisdn: String) = msisdn.length == 12

--- a/app/src/main/kotlin/pl/gov/mc/protego/ui/validator/MsisdnValidator.kt
+++ b/app/src/main/kotlin/pl/gov/mc/protego/ui/validator/MsisdnValidator.kt
@@ -10,16 +10,11 @@ object MsisdnInvalid : MsisdnValidationResult()
 object MsisdnOk : MsisdnValidationResult()
 
 class MsisdnValidator {
-    // https://pl.wikipedia.org/wiki/Numery_telefoniczne_w_Polsce#Sieci_ruchome_(komórkowe)
-    var prefixes = listOf(45, 50, 51, 53, 57, 60, 66, 69, 72, 73, 78, 79, 88).map{it.toString()}
 
     fun validate(msisdn: String) =
         when {
-            msisdn.length < 2 -> MsisdnIncomplete
-            msisdn.length < 9 ->
-                if (prefixes.any { msisdn.startsWith(it) }) MsisdnIncomplete else MsisdnInvalid
-            msisdn.length == 9 ->
-                if (prefixes.any { msisdn.startsWith(it) }) MsisdnOk else MsisdnInvalid
+            msisdn.length < 9 -> MsisdnIncomplete
+            msisdn.length == 9 ->MsisdnOk
             else -> MsisdnInvalid
         }
     fun validateWithCountryCode(msisdn: String) = msisdn.length == 12


### PR DESCRIPTION
Use a new type MsisdnValidationResult to distinguish incomplete Msisdn
from invalid ones
Add simple validation of phone number based on a 2-digit prefix

I added hiding the `register_button` when validation result is not Ok - mainly to demonstrate how we can utilise all 3 values of `MsisdnValidationResult`. 
Can change `isVisible` to `isClickable` if desired